### PR TITLE
Rework starter relic and basic shape change mechanics

### DIFF
--- a/cardData.md
+++ b/cardData.md
@@ -22,7 +22,7 @@ By mechanic:
  * Shapeshift: 7
  * Will-o-Wisp: 11
  * Soulsteal: 12
- * Shade: 3
+ * Shade: 4
  * Light: 5
  * Dark: 5
  * Charm: 3

--- a/cardData.md
+++ b/cardData.md
@@ -23,9 +23,9 @@ By mechanic:
  * Will-o-Wisp: 11
  * Soulsteal: 12
  * Shade: 4
- * Light: 5
- * Dark: 5
- * Charm: 3
+ * Light: 6
+ * Dark: 6
+ * Charm: 4
 
  * Elder: 4
  * Aspect: 10

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
         <!-- Change the path for your system to match your Steam installation. -->
         <!-- rin's version - <steam.windows>G:/SteamLibrary/steamapps</steam.windows> -->
-        <steam.windows>C:/Program Files (x86)/Steam/steamapps</steam.windows>
+        <steam.windows>G:/SteamLibrary/steamapps</steam.windows>
         <steam.mac>${user.home}/Library/Application Support/Steam/steamapps</steam.mac>
 
         <!-- These don't have to be up to date, it's just nice if they are. -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
         <!-- Change the path for your system to match your Steam installation. -->
         <!-- rin's version - <steam.windows>G:/SteamLibrary/steamapps</steam.windows> -->
-        <steam.windows>G:/SteamLibrary/steamapps</steam.windows>
+        <steam.windows>C:/Program Files (x86)/Steam/steamapps</steam.windows>
         <steam.mac>${user.home}/Library/Application Support/Steam/steamapps</steam.mac>
 
         <!-- These don't have to be up to date, it's just nice if they are. -->

--- a/src/main/java/kitsunemod/actions/KitsuneShapeAction.java
+++ b/src/main/java/kitsunemod/actions/KitsuneShapeAction.java
@@ -1,0 +1,65 @@
+package kitsunemod.actions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.vfx.combat.FlashAtkImgEffect;
+import kitsunemod.powers.CharmMonsterPower;
+
+public class KitsuneShapeAction extends AbstractGameAction {
+
+    private AbstractPlayer source;
+    private AbstractMonster target;
+    private int amount;
+    private DamageInfo damageInfo;
+
+    public KitsuneShapeAction(
+            final AbstractMonster target,
+            final AbstractPlayer source,
+            final int amount,
+            final DamageInfo damageInfo)
+
+    {
+        this.source = source;
+        this.target = target;
+        this.damageInfo = damageInfo;
+        this.amount = amount;
+        actionType = ActionType.DAMAGE;
+        this.duration = Settings.ACTION_DUR_FAST;
+    }
+
+    @Override
+    public void update() {
+        if (this.duration == Settings.ACTION_DUR_FAST) {
+            AbstractDungeon.effectList.add(new FlashAtkImgEffect(this.target.hb.cX, this.target.hb.cY, AttackEffect.SLASH_DIAGONAL));
+
+            if (shouldCharm()) {
+                AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(target, source, new CharmMonsterPower(target, amount)));
+            }
+
+            target.damage(damageInfo);
+
+            if (AbstractDungeon.getCurrRoom().monsters.areMonstersBasicallyDead()) {
+                AbstractDungeon.actionManager.clearPostCombatActions();
+            }
+        }
+        tickDuration();
+    }
+
+    private boolean shouldCharm() {
+        int tempDamage = this.damageInfo.base;
+
+        if (target.currentBlock > 0) {
+            tempDamage -= target.currentBlock;
+        }
+        if (tempDamage > target.currentHealth) {
+            tempDamage = target.currentHealth;
+        }
+
+        return (tempDamage > 0);
+    }
+}

--- a/src/main/java/kitsunemod/cards/attacks/FoxShape.java
+++ b/src/main/java/kitsunemod/cards/attacks/FoxShape.java
@@ -10,12 +10,15 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.orbs.Dark;
 import com.megacrit.cardcrawl.powers.WeakPower;
 import kitsunemod.KitsuneMod;
+import kitsunemod.actions.ApplyDarkAction;
 import kitsunemod.actions.ChangeShapeAction;
 import kitsunemod.cards.AbstractKitsuneCard;
 import kitsunemod.patches.AbstractCardEnum;
 import kitsunemod.patches.KitsuneTags;
+import kitsunemod.powers.DarkPower;
 import kitsunemod.powers.FoxShapePower;
 import kitsunemod.powers.ShadePower;
 
@@ -27,27 +30,28 @@ public class FoxShape extends AbstractKitsuneCard {
     public static final String IMG_PATH = "kitsunemod/images/cards/FoxShape.png";
 
     private static final int COST = 2;
-    private static final int ATTACK_DMG = 12;
-    private static final int SHADE_AMT = 1;
-    private static final int WEAK_AMT = 1;
-    private static final int UPGRADE_PLUS_SHADE = 1;
+    private static final int ATTACK_DMG = 2;
+    private static final int DARK_AMOUNT = 9;
+    private static final int WEAK_AMOUNT = 1;
+    private static final int UPGRADE_PLUS_DARK_AMOUNT = 6;
+    private static final int UPGRADE_PLUS_WEAK_AMOUNT = 1;
 
     public FoxShape() {
         super(ID, NAME, IMG_PATH, COST, DESCRIPTION,
                 CardType.ATTACK, AbstractCardEnum.KITSUNE_COLOR,
                 CardRarity.COMMON, CardTarget.ENEMY);
         damage = baseDamage = ATTACK_DMG;
-        magicNumber = baseMagicNumber = SHADE_AMT;
-        secondMagicNumber = baseSecondMagicNumber = WEAK_AMT;
+        magicNumber = baseMagicNumber = WEAK_AMOUNT;
+        secondMagicNumber = baseSecondMagicNumber = DARK_AMOUNT;
         exhaust = true;
         tags.add(KitsuneTags.SHAPESHIFT_CARD);
     }
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        AbstractDungeon.actionManager.addToBottom(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_DIAGONAL));
-        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(p, p, new ShadePower(AbstractDungeon.player, magicNumber)));
-        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(m, p, new WeakPower(m, 1, false)));
+        AbstractDungeon.actionManager.addToBottom(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.BLUNT_LIGHT));
+        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(m, p, new WeakPower(m, magicNumber, false)));
+        AbstractDungeon.actionManager.addToBottom(new ApplyDarkAction(p, p, secondMagicNumber));
         AbstractDungeon.actionManager.addToBottom(new ChangeShapeAction(p, p, new FoxShapePower(p, p)));
     }
 
@@ -60,7 +64,9 @@ public class FoxShape extends AbstractKitsuneCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
-            upgradeMagicNumber(UPGRADE_PLUS_SHADE);
+            upgradeMagicNumber(UPGRADE_PLUS_WEAK_AMOUNT);
+            upgradeSecondMagicNumber(UPGRADE_PLUS_DARK_AMOUNT);
+            initializeDescription();
         }
     }
 }

--- a/src/main/java/kitsunemod/cards/attacks/FoxShape.java
+++ b/src/main/java/kitsunemod/cards/attacks/FoxShape.java
@@ -1,6 +1,7 @@
 package kitsunemod.cards.attacks;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.DamageInfo;
@@ -9,12 +10,14 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.WeakPower;
 import kitsunemod.KitsuneMod;
 import kitsunemod.actions.ChangeShapeAction;
 import kitsunemod.cards.AbstractKitsuneCard;
 import kitsunemod.patches.AbstractCardEnum;
 import kitsunemod.patches.KitsuneTags;
 import kitsunemod.powers.FoxShapePower;
+import kitsunemod.powers.ShadePower;
 
 public class FoxShape extends AbstractKitsuneCard {
     public static final String ID = KitsuneMod.makeID("FoxShape");
@@ -25,13 +28,17 @@ public class FoxShape extends AbstractKitsuneCard {
 
     private static final int COST = 2;
     private static final int ATTACK_DMG = 12;
-    private static final int UPGRADE_PLUS_DMG = 4;
+    private static final int SHADE_AMT = 1;
+    private static final int WEAK_AMT = 1;
+    private static final int UPGRADE_PLUS_SHADE = 1;
 
     public FoxShape() {
         super(ID, NAME, IMG_PATH, COST, DESCRIPTION,
                 CardType.ATTACK, AbstractCardEnum.KITSUNE_COLOR,
                 CardRarity.COMMON, CardTarget.ENEMY);
         damage = baseDamage = ATTACK_DMG;
+        magicNumber = baseMagicNumber = SHADE_AMT;
+        secondMagicNumber = baseSecondMagicNumber = WEAK_AMT;
         exhaust = true;
         tags.add(KitsuneTags.SHAPESHIFT_CARD);
     }
@@ -39,6 +46,8 @@ public class FoxShape extends AbstractKitsuneCard {
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         AbstractDungeon.actionManager.addToBottom(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_DIAGONAL));
+        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(p, p, new ShadePower(AbstractDungeon.player, magicNumber)));
+        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(m, p, new WeakPower(m, 1, false)));
         AbstractDungeon.actionManager.addToBottom(new ChangeShapeAction(p, p, new FoxShapePower(p, p)));
     }
 
@@ -51,7 +60,7 @@ public class FoxShape extends AbstractKitsuneCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
-            upgradeDamage(UPGRADE_PLUS_DMG);
+            upgradeMagicNumber(UPGRADE_PLUS_SHADE);
         }
     }
 }

--- a/src/main/java/kitsunemod/cards/attacks/HumanShape.java
+++ b/src/main/java/kitsunemod/cards/attacks/HumanShape.java
@@ -1,8 +1,8 @@
 package kitsunemod.cards.attacks;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
-import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
@@ -10,7 +10,9 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.VulnerablePower;
 import kitsunemod.KitsuneMod;
+import kitsunemod.actions.ApplyLightAction;
 import kitsunemod.actions.ChangeShapeAction;
 import kitsunemod.cards.AbstractKitsuneCard;
 import kitsunemod.patches.AbstractCardEnum;
@@ -26,16 +28,18 @@ public class HumanShape extends AbstractKitsuneCard {
 
     private static final int COST = 2;
     private static final int ATTACK_DMG = 12;
-    private static final int UPGRADE_PLUS_DMG = 4;
-    private static final int BLOCK_AMT = 5;
-    private static final int UPGRADE_PLUS_BLOCK_AMT = 2;
+    private static final int VULNERABLE_AMOUNT = 1;
+    private static final int LIGHT_AMOUNT = 9;
+    private static final int UPGRADE_PLUS_LIGHT_AMOUNT = 6;
+    private static final int UPGRADE_PLUS_VULNERABLE_AMOUNT = 1;
 
     public HumanShape() {
         super(ID, NAME, IMG_PATH, COST, DESCRIPTION,
                 CardType.ATTACK, AbstractCardEnum.KITSUNE_COLOR,
                 CardRarity.COMMON, CardTarget.ENEMY);
         damage = baseDamage = ATTACK_DMG;
-        block = baseBlock = BLOCK_AMT;
+        magicNumber = baseMagicNumber = VULNERABLE_AMOUNT;
+        secondMagicNumber = baseSecondMagicNumber = LIGHT_AMOUNT;
         exhaust = true;
         tags.add(KitsuneTags.SHAPESHIFT_CARD);
     }
@@ -43,7 +47,8 @@ public class HumanShape extends AbstractKitsuneCard {
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         AbstractDungeon.actionManager.addToBottom(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_DIAGONAL));
-        AbstractDungeon.actionManager.addToBottom(new GainBlockAction(p, p, block));
+        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(m, p, new VulnerablePower(m, magicNumber, false)));
+        AbstractDungeon.actionManager.addToBottom(new ApplyLightAction(p, p, secondMagicNumber));
         AbstractDungeon.actionManager.addToBottom(new ChangeShapeAction(p, p, new HumanShapePower(p, p)));
     }
 
@@ -56,8 +61,9 @@ public class HumanShape extends AbstractKitsuneCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
-            upgradeDamage(UPGRADE_PLUS_DMG);
-            upgradeBlock(UPGRADE_PLUS_BLOCK_AMT);
+            upgradeMagicNumber(UPGRADE_PLUS_VULNERABLE_AMOUNT);
+            upgradeSecondMagicNumber(UPGRADE_PLUS_LIGHT_AMOUNT);
+            initializeDescription();
         }
     }
 }

--- a/src/main/java/kitsunemod/cards/attacks/KitsuneShape.java
+++ b/src/main/java/kitsunemod/cards/attacks/KitsuneShape.java
@@ -13,9 +13,11 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.WeakPower;
 import kitsunemod.KitsuneMod;
 import kitsunemod.actions.ChangeShapeAction;
+import kitsunemod.actions.KitsuneShapeAction;
 import kitsunemod.cards.AbstractKitsuneCard;
 import kitsunemod.patches.AbstractCardEnum;
 import kitsunemod.patches.KitsuneTags;
+import kitsunemod.powers.CharmMonsterPower;
 import kitsunemod.powers.KitsuneShapePower;
 
 public class KitsuneShape extends AbstractKitsuneCard {
@@ -26,25 +28,24 @@ public class KitsuneShape extends AbstractKitsuneCard {
     public static final String IMG_PATH = "kitsunemod/images/cards/KitsuneShape.png";
 
     private static final int COST = 2;
-    private static final int ATTACK_DMG = 12;
+    private static final int ATTACK_DMG = 6;
     private static final int UPGRADE_PLUS_DMG = 4;
-    private static final int WEAK_AMT = 1;
-    private static final int UPGRADE_PLUS_WEAK_AMT = 1;
+    private static final int CHARM_TURNS = 1;
+    private static final int UPGRADE_NEW_COST = 1;
 
     public KitsuneShape() {
         super(ID, NAME, IMG_PATH, COST, DESCRIPTION,
                 CardType.ATTACK, AbstractCardEnum.KITSUNE_COLOR,
                 CardRarity.COMMON, CardTarget.ENEMY);
         damage = baseDamage = ATTACK_DMG;
-        magicNumber = baseMagicNumber = WEAK_AMT;
+        magicNumber = baseMagicNumber = CHARM_TURNS;
         exhaust = true;
         tags.add(KitsuneTags.SHAPESHIFT_CARD);
     }
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        AbstractDungeon.actionManager.addToBottom(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_DIAGONAL));
-        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(m, p, new WeakPower(m, magicNumber, false)));
+        AbstractDungeon.actionManager.addToBottom(new KitsuneShapeAction(m, p, magicNumber, new DamageInfo(p, damage, damageTypeForTurn)));
         AbstractDungeon.actionManager.addToBottom(new ChangeShapeAction(p, p, new KitsuneShapePower(p, p)));
     }
 
@@ -58,7 +59,7 @@ public class KitsuneShape extends AbstractKitsuneCard {
         if (!upgraded) {
             upgradeName();
             upgradeDamage(UPGRADE_PLUS_DMG);
-            upgradeMagicNumber(UPGRADE_PLUS_WEAK_AMT);
+            upgradeBaseCost(UPGRADE_NEW_COST);
         }
     }
 }

--- a/src/main/java/kitsunemod/cards/basic/ChangeShape.java
+++ b/src/main/java/kitsunemod/cards/basic/ChangeShape.java
@@ -22,7 +22,7 @@ public class ChangeShape extends AbstractKitsuneCard implements ModalChoice.Call
     public static final String DESCRIPTION = cardStrings.DESCRIPTION;
     public static final String IMG_PATH = "kitsunemod/images/cards/ChangeShape.png";
 
-    private static final int COST = 1;
+    private static final int COST = 0;
 
     private ModalChoice modal;
 
@@ -38,6 +38,7 @@ public class ChangeShape extends AbstractKitsuneCard implements ModalChoice.Call
                 .addOption(new HumanShapeOption())
                 .create();
         exhaust = true;
+        retain = true;
     }
 
     @Override

--- a/src/main/java/kitsunemod/cards/basic/ChangeShape.java
+++ b/src/main/java/kitsunemod/cards/basic/ChangeShape.java
@@ -2,6 +2,7 @@ package kitsunemod.cards.basic;
 
 import basemod.helpers.ModalChoice;
 import basemod.helpers.ModalChoiceBuilder;
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.AlwaysRetainField;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -38,7 +39,7 @@ public class ChangeShape extends AbstractKitsuneCard implements ModalChoice.Call
                 .addOption(new HumanShapeOption())
                 .create();
         exhaust = true;
-        retain = true;
+        AlwaysRetainField.alwaysRetain.set(this, true);
     }
 
     @Override

--- a/src/main/java/kitsunemod/character/KitsuneCharacter.java
+++ b/src/main/java/kitsunemod/character/KitsuneCharacter.java
@@ -319,7 +319,7 @@ public class KitsuneCharacter extends CustomPlayer {
         retVal.add(Defend.ID);
         retVal.add(Defend.ID);
         retVal.add(Wink.ID);
-        retVal.add(ChangeShape.ID);
+        //retVal.add(ChangeShape.ID);
         return retVal;
     }
 

--- a/src/main/java/kitsunemod/powers/FoxShapePower.java
+++ b/src/main/java/kitsunemod/powers/FoxShapePower.java
@@ -13,8 +13,8 @@ import kitsunemod.actions.ApplyDarkAction;
 public class FoxShapePower extends AbstractShapePower {
 
     //set in WornPearl, LuminousPearl, and ShiningPearl if you're looking for the base strength/dex amounts
-    public static int BONUS_DEXTERITY = 0;
-    public static int BONUS_STRENGTH = 0;
+    public static int BONUS_DEXTERITY = 3;
+    public static int BONUS_STRENGTH = 1;
     public static int STACKS_PER_SOULSTEAL = 2;
 
     public static final String POWER_ID = KitsuneMod.makeID("FoxShapePower");

--- a/src/main/java/kitsunemod/powers/HumanShapePower.java
+++ b/src/main/java/kitsunemod/powers/HumanShapePower.java
@@ -13,8 +13,8 @@ import kitsunemod.actions.ApplyLightAction;
 public class HumanShapePower extends AbstractShapePower {
 
     //set in WornPearl, LuminousPearl, and ShiningPearl if you're looking for the base strength/dex amounts
-    public static int BONUS_DEXTERITY = 0;
-    public static int BONUS_STRENGTH = 0;
+    public static int BONUS_DEXTERITY = 1;
+    public static int BONUS_STRENGTH = 3;
     public static int STACKS_PER_SOULSTEAL = 2;
 
     public static final String POWER_ID = KitsuneMod.makeID("HumanShapePower");

--- a/src/main/java/kitsunemod/powers/KitsuneShapePower.java
+++ b/src/main/java/kitsunemod/powers/KitsuneShapePower.java
@@ -14,8 +14,8 @@ import kitsunemod.actions.CreateWillOWispAction;
 public class KitsuneShapePower extends AbstractShapePower {
 
     //set in WornPearl, LuminousPearl, and ShiningPearl if you're looking for the base strength/dex amounts
-    public static int BONUS_DEXTERITY = 0;
-    public static int BONUS_STRENGTH = 0;
+    public static int BONUS_DEXTERITY = 2;
+    public static int BONUS_STRENGTH = 2;
     public static int SOULSTEAL_STACKS_PER_WISP = 5;
     public static int WISPS_PER_INCREMENT = 1;
 

--- a/src/main/java/kitsunemod/relics/ShiningPearl.java
+++ b/src/main/java/kitsunemod/relics/ShiningPearl.java
@@ -1,11 +1,14 @@
 package kitsunemod.relics;
 
 import com.badlogic.gdx.graphics.Texture;
+import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
+import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.PowerTip;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import kitsunemod.KitsuneMod;
 import kitsunemod.actions.CreateWillOWispAction;
+import kitsunemod.cards.basic.ChangeShape;
 import kitsunemod.powers.AbstractShapePower;
 import kitsunemod.powers.FoxShapePower;
 import kitsunemod.powers.HumanShapePower;
@@ -20,12 +23,12 @@ public class ShiningPearl extends KitsuneRelic {
         super(ID, IMG, OUTLINE, RelicTier.BOSS, LandingSound.MAGICAL);
     }
 
-    public static final int FOX_BONUS_STR = 1;
-    public static final int FOX_BONUS_DEX = 4;
-    public static final int KITSUNE_BONUS_STR = 2;
-    public static final int KITSUNE_BONUS_DEX = 2;
-    public static final int HUMAN_BONUS_STR = 4;
-    public static final int HUMAN_BONUS_DEX = 1;
+    public static final int FOX_BONUS_STR = 0;
+    public static final int FOX_BONUS_DEX = 2;
+    public static final int KITSUNE_BONUS_STR = 1;
+    public static final int KITSUNE_BONUS_DEX = 1;
+    public static final int HUMAN_BONUS_STR = 2;
+    public static final int HUMAN_BONUS_DEX = 0;
     public static final int KITSUNE_WILLOWISPS_AMOUNT = 1;
 
     @Override
@@ -56,6 +59,11 @@ public class ShiningPearl extends KitsuneRelic {
         this.initializeTips();
     }
 
+    @Override
+    public void atBattleStart() {
+        this.addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
+        this.addToBot(new MakeTempCardInHandAction(new ChangeShape()));
+    }
     @Override
     public void atTurnStartPostDraw() {
         if (AbstractDungeon.player.hasPower(KitsuneShapePower.POWER_ID)) {

--- a/src/main/java/kitsunemod/relics/WornPearl.java
+++ b/src/main/java/kitsunemod/relics/WornPearl.java
@@ -24,66 +24,10 @@ public class WornPearl extends KitsuneRelic {
     }
 
 
-    public static final int FOX_BONUS_STR = 0;
-    public static final int FOX_BONUS_DEX = 4;
-    public static final int KITSUNE_BONUS_STR = 2;
-    public static final int KITSUNE_BONUS_DEX = 2;
-    public static final int HUMAN_BONUS_STR = 4;
-    public static final int HUMAN_BONUS_DEX = 0;
-
-
-    @Override
-    public void atPreBattle() {
-        FoxShapePower.BONUS_STRENGTH = FOX_BONUS_STR;
-        FoxShapePower.BONUS_DEXTERITY = FOX_BONUS_DEX;
-
-        KitsuneShapePower.BONUS_STRENGTH = KITSUNE_BONUS_STR;
-        KitsuneShapePower.BONUS_DEXTERITY = KITSUNE_BONUS_DEX;
-
-        HumanShapePower.BONUS_STRENGTH = HUMAN_BONUS_STR;
-        HumanShapePower.BONUS_DEXTERITY = HUMAN_BONUS_DEX;
-    }
-
     @Override
     public void atBattleStart() {
         this.addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
         this.addToBot(new MakeTempCardInHandAction(new ChangeShape()));
-    }
-
-    @Override
-    public void onVictory() {
-        FoxShapePower.BONUS_STRENGTH = 0;
-        FoxShapePower.BONUS_DEXTERITY = 0;
-
-        KitsuneShapePower.BONUS_STRENGTH = 0;
-        KitsuneShapePower.BONUS_DEXTERITY = 0;
-
-        HumanShapePower.BONUS_STRENGTH = 0;
-        HumanShapePower.BONUS_DEXTERITY = 0;
-        description = getUpdatedDescription();
-        this.tips.clear();
-        this.tips.add(new PowerTip(name,description));
-        this.initializeTips();
-    }
-
-    @Override
-    public void onChangeShape(KitsuneMod.KitsuneShapes shape, AbstractShapePower shapePower) {
-        description = DESCRIPTIONS[0];
-
-        //TODO handle ninetailed form; for that matter decide what we want to do with ninetailed form re: str/dex now
-        if (shape == KitsuneMod.KitsuneShapes.FOX) {
-            description += DESCRIPTIONS[1] + FOX_BONUS_STR + DESCRIPTIONS[4] + FOX_BONUS_DEX + DESCRIPTIONS[5];
-        }
-        if (shape == KitsuneMod.KitsuneShapes.KITSUNE) {
-            description += DESCRIPTIONS[2] + KITSUNE_BONUS_STR + DESCRIPTIONS[4] + KITSUNE_BONUS_DEX + DESCRIPTIONS[5];
-        }
-        if (shape == KitsuneMod.KitsuneShapes.HUMAN) {
-            description += DESCRIPTIONS[3] + FOX_BONUS_STR + DESCRIPTIONS[4] + FOX_BONUS_DEX + DESCRIPTIONS[5];
-        }
-
-        this.tips.clear();
-        this.tips.add(new PowerTip(name, description));
-        this.initializeTips();
     }
 
     @Override

--- a/src/main/java/kitsunemod/relics/WornPearl.java
+++ b/src/main/java/kitsunemod/relics/WornPearl.java
@@ -1,9 +1,14 @@
 package kitsunemod.relics;
 
 import com.badlogic.gdx.graphics.Texture;
+import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
+import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.PowerTip;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.vfx.RelicAboveCreatureEffect;
 import kitsunemod.KitsuneMod;
+import kitsunemod.cards.basic.ChangeShape;
 import kitsunemod.powers.AbstractShapePower;
 import kitsunemod.powers.FoxShapePower;
 import kitsunemod.powers.HumanShapePower;
@@ -37,6 +42,12 @@ public class WornPearl extends KitsuneRelic {
 
         HumanShapePower.BONUS_STRENGTH = HUMAN_BONUS_STR;
         HumanShapePower.BONUS_DEXTERITY = HUMAN_BONUS_DEX;
+    }
+
+    @Override
+    public void atBattleStart() {
+        this.addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
+        this.addToBot(new MakeTempCardInHandAction(new ChangeShape()));
     }
 
     @Override

--- a/src/main/resources/kitsunemod/strings/eng/cards.json
+++ b/src/main/resources/kitsunemod/strings/eng/cards.json
@@ -34,8 +34,8 @@
   },
   "kitsunemod:ChangeShape": {
     "NAME": "Change Shape",
-    "DESCRIPTION": "Choose a kitsunemod:Shape to kitsunemod:Shapeshift into.",
-    "UPGRADE_DESCRIPTION": "Innate. NL Choose a kitsunemod:Shape to kitsunemod:Shapeshift into. NL Exhaust."
+    "DESCRIPTION": "Retain. NL Choose a kitsunemod:Shape to kitsunemod:Shapeshift into.NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "Retain. Innate. NL Choose a kitsunemod:Shape to kitsunemod:Shapeshift into. NL Exhaust."
   },
   "kitsunemod:ChangeShapeOptionFoxShape": {
     "NAME": "Fox Shape",

--- a/src/main/resources/kitsunemod/strings/eng/cards.json
+++ b/src/main/resources/kitsunemod/strings/eng/cards.json
@@ -155,7 +155,7 @@
   },
   "kitsunemod:FoxShape": {
     "NAME": "Fox Shape",
-    "DESCRIPTION": "Deal !D! Damage. Gain !M! kitsunemod:Shade. Apply !kitsunemod:M2! Weak. NL kitsunemod:Shapeshift into a Fox. NL Exhaust.",
+    "DESCRIPTION": "Deal !D! Damage. Gain !kitsunemod:M2! kitsunemod:Dark. Apply !M! Weak. NL kitsunemod:Shapeshift into a Fox. NL Exhaust.",
     "UPGRADE_DESCRIPTION": ""
   },
   "kitsunemod:GatheringDark": {
@@ -198,7 +198,7 @@
   },
   "kitsunemod:HumanShape": {
     "NAME": "Human Shape",
-    "DESCRIPTION": "Deal !D! Damage. Gain !B! Block. kitsunemod:Shapeshift into a Human. NL Exhaust.",
+    "DESCRIPTION": "Deal !D! Damage. Gain !kitsunemod:M2! kitsunemod:Light. Apply !M! Vulnerable. NL kitsunemod:Shapeshift into a Fox. NL Exhaust.",
     "UPGRADE_DESCRIPTION": ""
   },
   "kitsunemod:HungryStrikes": {
@@ -228,7 +228,7 @@
   },
   "kitsunemod:KitsuneShape": {
     "NAME": "Kitsune Shape",
-    "DESCRIPTION": "Deal !D! Damage. Apply !M! Weak. kitsunemod:Shapeshift into a Kitsune. NL Exhaust.",
+    "DESCRIPTION": "Deal !D! Damage. If this deals unblocked damage, kitsunemod:Charm for !M! turn. NL kitsunemod:Shapeshift into a Kitsune. NL Exhaust.",
     "UPGRADE_DESCRIPTION": ""
   },
   "kitsunemod:LashOut": {

--- a/src/main/resources/kitsunemod/strings/eng/cards.json
+++ b/src/main/resources/kitsunemod/strings/eng/cards.json
@@ -155,7 +155,7 @@
   },
   "kitsunemod:FoxShape": {
     "NAME": "Fox Shape",
-    "DESCRIPTION": "Deal !D! Damage. kitsunemod:Shapeshift into a Fox. NL Exhaust.",
+    "DESCRIPTION": "Deal !D! Damage. Gain !M! kitsunemod:Shade. Apply !kitsunemod:M2! Weak. NL kitsunemod:Shapeshift into a Fox. NL Exhaust.",
     "UPGRADE_DESCRIPTION": ""
   },
   "kitsunemod:GatheringDark": {

--- a/src/main/resources/kitsunemod/strings/eng/cards.json
+++ b/src/main/resources/kitsunemod/strings/eng/cards.json
@@ -34,7 +34,7 @@
   },
   "kitsunemod:ChangeShape": {
     "NAME": "Change Shape",
-    "DESCRIPTION": "Choose a kitsunemod:Shape to kitsunemod:Shapeshift into. NL Exhaust.",
+    "DESCRIPTION": "Choose a kitsunemod:Shape to kitsunemod:Shapeshift into.",
     "UPGRADE_DESCRIPTION": "Innate. NL Choose a kitsunemod:Shape to kitsunemod:Shapeshift into. NL Exhaust."
   },
   "kitsunemod:ChangeShapeOptionFoxShape": {

--- a/src/main/resources/kitsunemod/strings/eng/relics.json
+++ b/src/main/resources/kitsunemod/strings/eng/relics.json
@@ -35,19 +35,14 @@
     "NAME": "Worn Pearl",
     "FLAVOR": "As close to me as my heart.",
     "DESCRIPTIONS": [
-      "Your cards deal more damage and gain more #yBlock depending on your #ykitsunemod:Shape.",
-      " NL Fox #ykitsunemod:Aspect: ",
-      " NL Kitsune #ykitsunemod:Aspect: ",
-      " NL Human #ykitsunemod:Aspect: ",
-      " extra damage, ",
-      " extra #yBlock."
+      "At the start of combat, add a #yChange #yShape to your hand. "
     ]
   },
   "kitsunemod:ShiningPearl": {
     "NAME": "Shining Pearl",
     "FLAVOR": "Just like when I was young!",
     "DESCRIPTIONS": [
-      "Your cards deal more damage and gain more #yBlock depending on your #ykitsunemod:Shape.",
+      "At the start of combat, add a #yChange #yShape to your hand. Your cards deal more damage and gain more #yBlock depending on your #ykitsunemod:Shape.",
       " NL Fox #ykitsunemod:Aspect: ",
       " NL Kitsune #ykitsunemod:Aspect: ",
       " NL Human #ykitsunemod:Aspect: ",
@@ -60,9 +55,9 @@
   },
   "kitsunemod:LuminousPearl": {
     "NAME": "Luminous Pearl",
-    "FLAVOR": "It would seem that with my offering, I have ascended to become an elder spirit.",
+    "FLAVOR": "With my offering, I have ascended to become an elder spirit.",
     "DESCRIPTIONS": [
-      "Start each fight in Ninetailed #ykitsunemod:Shape and #yExhaust all #ykitsunemod:Shapeshift cards in your deck. For each card #yExhausted this way, your cards deal 1 more damage and gain 1 more #yBlock."
+      "Start each combat in Ninetailed #ykitsunemod:Shape and #yExhaust all #ykitsunemod:Shapeshift cards in your deck. For each card #yExhausted this way, your cards deal 1 more damage and gain 1 more #yBlock."
     ]
   },
   "kitsunemod:MiniatureFountain": {


### PR DESCRIPTION
Does the following:

 * Stat bonuses from shapes are innate to the shape
 * Change Shape is no longer in the starter deck/collectible, is 0 cost, and has innate
 * Worn Pearl now instead adds a Change Shape to your hand
 * Shining Pearl now also adds a Change Shape to your hand
 * Reworked the effects of the 2-cost shape change attacks